### PR TITLE
移动版添加种子页面增加常用文件夹选择框，方便快速选择常用文件夹

### DIFF
--- a/src/index.mobile.html
+++ b/src/index.mobile.html
@@ -104,6 +104,8 @@
 				<textarea id="torrent-url" style="height:130px;"></textarea>
 				<label for="download-dir" system-lang="dialog['torrent-add']['download-dir']"></label>
 				<input id="download-dir"/>
+                <label for="used-download-dir" system-lang="dialog['torrent-add']['used-download-dir']"></label>
+                <select id="used-download-dir" data-mini="true"></select>
 				<div data-role="fieldcontain">
 					<label for="autostart" system-lang="dialog['torrent-add']['autostart']"></label>
 					<select name="autostart" id="autostart" data-role="slider">
@@ -172,6 +174,15 @@
 		$('#download-dir').val(system.downloadDir);
 		system.showContent('add-torrent');
 		$("#navPanel").panel("close");
+
+        //将常用目录初始化,并设置默认目录
+        var $usedDownloadDir = $("#used-download-dir");
+        $usedDownloadDir.empty();
+        $.each(transmission.downloadDirs, function( index, dir ) {
+            $usedDownloadDir.append(new Option(dir, dir));
+        });
+        $usedDownloadDir.val(system.downloadDir).selectmenu('refresh', true);
+
 	}
 	function addUrl()
 	{
@@ -228,6 +239,10 @@
 			system.control.torrentlist.find("input[type='checkbox']").prop("checked",checked).checkboxradio("refresh");
 			system.changeTorrentToolbar();
 		});
+
+        $("#used-download-dir").change(function(){
+            $('#download-dir').val($(this).val());
+        });
 
 		function saveConfig()
 		{

--- a/src/tr-web-control/i18n/en.json
+++ b/src/tr-web-control/i18n/en.json
@@ -136,6 +136,7 @@
 	"dialog": {
 		"torrent-add": {
 			"download-dir": "Download Dir:",
+            "used-download-dir": "Used Download Dir:",
 			"torrent-url": "Torrent URL:",
 			"tip-torrent-url": "Tip: Please add multiple content with an 'Enter' key press to separate",
 			"autostart": "Auto Start:",

--- a/src/tr-web-control/i18n/zh_CN.json
+++ b/src/tr-web-control/i18n/zh_CN.json
@@ -136,6 +136,7 @@
 	"dialog": {
 		"torrent-add": {
 			"download-dir": "保存目录：",
+		    "used-download-dir": "常用目录：",
 			"torrent-url": "种子地址：",
 			"tip-torrent-url": "注：复制种子链接到列表中，多个种子用“回车”分隔。",
 			"autostart": "自动开始：",

--- a/src/tr-web-control/i18n/zh_TW.json
+++ b/src/tr-web-control/i18n/zh_TW.json
@@ -136,6 +136,7 @@
 	"dialog": {
 		"torrent-add": {
 			"download-dir": "下載資料夾：",
+            "used-download-dir": "常用資料夾：",
 			"torrent-url": "磁力連結：",
 			"tip-torrent-url": "註：貼上磁力連結，多個磁力連結用「換行」分隔。",
 			"autostart": "自動開始：",

--- a/src/tr-web-control/style/base.mobile.css
+++ b/src/tr-web-control/style/base.mobile.css
@@ -224,3 +224,7 @@
 .torrent-list-infos{
 	font-size:12px;font-family:arial,sans-serif;
 }
+
+.ui-select span{
+	text-align:left !important;
+}


### PR DESCRIPTION
移动版添加种子页面增加常用文件夹选择框，方便快速选择常用文件夹。原始下载目录仍旧可用，只是增加了文件夹选择的快捷方法，方便在不同目录中切换。