### PR TITLE
修复磁力链任务不更新任务信息

### DIFF
--- a/src/tr-web-control/script/system.js
+++ b/src/tr-web-control/script/system.js
@@ -85,6 +85,8 @@ var system = {
 	checkedRows: [],
 	uiIsInitialized: false,
 	popoverCount: 0,
+	// 当前数据目录，用于添加任务的快速保存路径选择
+	currentListDir: "",
 	/**
 	 * 设置语言
 	 */
@@ -636,6 +638,7 @@ var system = {
 				system.loadTorrentToList({
 					node: node
 				});
+				system.currentListDir = node.downDir;
 			},
 			lines: true
 		});
@@ -3000,6 +3003,7 @@ var system = {
 					this.appendTreeNode(parentkey, [{
 						id: key,
 						path: path,
+						downDir: fullkey,
 						text: text,
 						iconCls: "iconfont tr-icon-file"
 					}]);

--- a/src/tr-web-control/script/system.js
+++ b/src/tr-web-control/script/system.js
@@ -2595,7 +2595,9 @@ var system = {
 				}
 
 				torrent.completeSize = (torrent.totalSize - torrent.leftUntilDone);
-				torrent.moreInfosTag = true;
+				if (("files" in torrent) && torrent.files.length > 0) {
+					torrent.moreInfosTag = true;
+				}
 				system.fillTorrentBaseInfos(torrent);
 				system.fillTorrentFileList(torrent);
 				system.fillTorrentServerList(torrent);

--- a/src/tr-web-control/script/transmission.torrents.js
+++ b/src/tr-web-control/script/transmission.torrents.js
@@ -16,7 +16,7 @@ transmission.torrents = {
 	pausedTorrentCount: 0,
 	fields: {
 		base: "id,name,status,hashString,totalSize,percentDone,addedDate,trackerStats,leftUntilDone,rateDownload,rateUpload,recheckProgress" + ",rateDownload,rateUpload,peersGettingFromUs,peersSendingToUs,uploadRatio,uploadedEver,downloadedEver,downloadDir,error,errorString,doneDate,queuePosition,activityDate",
-		status: "id,status,percentDone,trackerStats,leftUntilDone,rateDownload,rateUpload" + ",rateDownload,rateUpload,peersGettingFromUs,peersSendingToUs,uploadRatio,uploadedEver,downloadedEver,error,errorString,doneDate,queuePosition,activityDate",
+		status: "id,name,status,totalSize,percentDone,trackerStats,leftUntilDone,rateDownload,rateUpload" + ",rateDownload,rateUpload,peersGettingFromUs,peersSendingToUs,uploadRatio,uploadedEver,downloadedEver,error,errorString,doneDate,queuePosition,activityDate",
 		config: "downloadLimit,downloadLimited,peer-limit,seedIdleLimit,seedIdleMode,seedRatioLimit,seedRatioMode,uploadLimit,uploadLimited"
 	},
 	// List of all the torrents that have been acquired

--- a/src/tr-web-control/script/transmission.torrents.js
+++ b/src/tr-web-control/script/transmission.torrents.js
@@ -296,11 +296,7 @@ transmission.torrents = {
 			}
 
 			if (warnings.length == trackerStats.length) {
-				if ((warnings.join(";")).replace(/;/g,"") == ""){
-					item["warning"] = ""
-				} else {
-					item["warning"] = warnings.join(";");
-				}
+				item["warning"] = warnings.join(";");
 				// 设置下次更新时间
 				if (!item["nextAnnounceTime"])
 					item["nextAnnounceTime"] = trackerInfo.nextAnnounceTime;

--- a/src/tr-web-control/script/transmission.torrents.js
+++ b/src/tr-web-control/script/transmission.torrents.js
@@ -296,7 +296,11 @@ transmission.torrents = {
 			}
 
 			if (warnings.length == trackerStats.length) {
-				item["warning"] = warnings.join(";");
+				if ((warnings.join(";")).replace(/;/g,"") == ""){
+					item["warning"] = "";
+				} else {
+					item["warning"] = warnings.join(";");
+				}
 				// 设置下次更新时间
 				if (!item["nextAnnounceTime"])
 					item["nextAnnounceTime"] = trackerInfo.nextAnnounceTime;

--- a/src/tr-web-control/script/transmission.torrents.js
+++ b/src/tr-web-control/script/transmission.torrents.js
@@ -296,7 +296,11 @@ transmission.torrents = {
 			}
 
 			if (warnings.length == trackerStats.length) {
-				item["warning"] = warnings.join(";");
+				if ((warnings.join(";")).replace(/;/g,"") == ""){
+					item["warning"] = ""
+				} else {
+					item["warning"] = warnings.join(";");
+				}
 				// 设置下次更新时间
 				if (!item["nextAnnounceTime"])
 					item["nextAnnounceTime"] = trackerInfo.nextAnnounceTime;

--- a/src/tr-web-control/template/dialog-torrent-add.html
+++ b/src/tr-web-control/template/dialog-torrent-add.html
@@ -80,6 +80,12 @@
 			$.merge(downloadDirs,system.dictionary.folders.split("\n"));
 		}
 		downloadDirs = uniq(downloadDirs);
+
+		if (system.config.hideSubfolders == false && system.currentListDir != null && system.currentListDir != "") {
+			// 增加 当前数据目录为第一候选
+			downloadDirs.unshift(system.currentListDir);
+		}
+
 		if (downloadDirs == null)
 		{
 			$("<option/>").text(system.downloadDir).val(system.downloadDir).attr("selected",true).appendTo(thisDialog.find("#download-dir"));

--- a/src/tr-web-control/template/dialog-torrent-addfile.html
+++ b/src/tr-web-control/template/dialog-torrent-addfile.html
@@ -69,6 +69,12 @@
 			$.merge(downloadDirs,system.dictionary.folders.split("\n"));
 		}
 		downloadDirs = uniq(downloadDirs);
+		
+		if (system.config.hideSubfolders == false && system.currentListDir != null && system.currentListDir != "") {
+			// 增加 当前数据目录为第一候选
+			downloadDirs.unshift(system.currentListDir);
+		}
+
 		if (downloadDirs == null)
     {
 			$("<option/>").text(system.downloadDir).val(system.downloadDir).attr("selected",true).appendTo(thisDialog.find("#download-dir"));

--- a/src/tr-web-control/template/dialog-torrent-rename.html
+++ b/src/tr-web-control/template/dialog-torrent-rename.html
@@ -65,6 +65,7 @@
 							return;
 						}
 						
+						torrent.moreInfosTag = false;
 						system.reloadTorrentBaseInfos(data.arguments.id, ["name"]);						
 						thisDialog.dialog("close");
 					}


### PR DESCRIPTION
修正 #378 
1. 活跃任务信息增加 `name`、`totalSize` 字段（如果放在下一条中处理会只有点击该任务才会更新）
2. 是否需要更新更多的任务信息根据文件列表是否为空来判断