### PR TITLE
增加 显示peer和tracker的更多信息

### DIFF
--- a/src/tr-web-control/i18n/en.json
+++ b/src/tr-web-control/i18n/en.json
@@ -370,10 +370,20 @@
 				"lastAnnounceTime": "AnnounceTime",
 				"lastAnnounceTimedOut": "TimedOut",
 				"downloadCount": "Download count",
-				"nextAnnounceTime": "Next announce"
+				"nextAnnounceTime": "Next announce",
+				"leecherCount": "Leecher count",
+				"seederCount": "Seeder count",
+				"announceStateText": {
+					"0": "Inactive",
+					"1": "Waiting",
+					"2": "Queued",
+					"3": "Active"
+				}
 			},
 			"peers-fields": {
 				"address": "IP address",
+				"port": "Port",
+				"isUTP": "UTP enabled",
 				"clientName": "Client",
 				"flagStr": "Flag",
 				"progress": "Progress",

--- a/src/tr-web-control/i18n/zh_CN.json
+++ b/src/tr-web-control/i18n/zh_CN.json
@@ -373,6 +373,8 @@
 			},
 			"peers-fields": {
 				"address": "IP地址",
+				"port": "端口",
+				"isUTP": "UTP连接",
 				"clientName": "客户端",
 				"flagStr": "标记",
 				"progress": "完成进度",

--- a/src/tr-web-control/i18n/zh_CN.json
+++ b/src/tr-web-control/i18n/zh_CN.json
@@ -292,6 +292,8 @@
 			"newname": "新名称"
 		},
 		"torrent-attribute-add-tracker": {
+			"button-search-best-ip": "精选(IP)",
+			"button-search-all-ip": "全部(IP)",
 			"title": "增加 Tracker",
 			"tip": "每行表示一个Tracker"
 		},
@@ -368,8 +370,16 @@
 				"lastAnnounceSucceeded": "已连接",
 				"lastAnnounceTime": "更新时间",
 				"lastAnnounceTimedOut": "超时",
-				"downloadCount": "总下载数",
-				"nextAnnounceTime": "下次更新时间"
+				"downloadCount": "下载数",
+				"leecherCount": "吸血数",
+				"seederCount": "种子数",
+				"nextAnnounceTime": "下次更新时间",
+				"announceStateText": {
+					"0": "非活动",
+					"1": "待机",
+					"2": "队列中",
+					"3": "活动中"
+				}
 			},
 			"peers-fields": {
 				"address": "IP地址",

--- a/src/tr-web-control/i18n/zh_TW.json
+++ b/src/tr-web-control/i18n/zh_TW.json
@@ -288,6 +288,8 @@
 			"newname": "新名稱"
 		},
 		"torrent-attribute-add-tracker": {
+			"button-search-best-ip": "精選(IP)",
+			"button-search-all-ip": "全部(IP)",
 			"title": "新增 Tracker",
 			"tip": "每行一個 Tracker"
 		},
@@ -354,7 +356,15 @@
 				"lastAnnounceTime": "更新時間",
 				"lastAnnounceTimedOut": "超時",
 				"downloadCount": "下載數",
-				"nextAnnounceTime": "下次更新時間"
+				"leecherCount": "吸血數",
+				"seederCount": "種子數",
+				"nextAnnounceTime": "下次更新時間",
+				"announceStateText": {
+					"0": "非活動",
+					"1": "待機",
+					"2": "佇列中",
+					"3": "活動中"
+				}
 			},
 			"peers-fields": {
 				"address": "IP 地址",

--- a/src/tr-web-control/i18n/zh_TW.json
+++ b/src/tr-web-control/i18n/zh_TW.json
@@ -358,6 +358,8 @@
 			},
 			"peers-fields": {
 				"address": "IP 地址",
+				"port": "連接埠",
+				"isUTP": "UTP連接",
 				"clientName": "用戶端",
 				"flagStr": "標記",
 				"progress": "進度",

--- a/src/tr-web-control/script/system.js
+++ b/src/tr-web-control/script/system.js
@@ -2760,6 +2760,16 @@ var system = {
 			var rowdata = {};
 			for (var key in stats) {
 				switch (key) {
+					case "downloadCount":
+					case "leecherCount":
+					case "seederCount":
+						rowdata[key] = (stats[key] == -1 ? system.lang["public"]["text-unknown"] : stats[key]);
+						break;
+
+					// state
+					case "announceState":
+						rowdata[key] = system.lang.torrent.attribute["servers-fields"]["announceStateText"][stats[key]];
+						break;
 					// Dates
 					case "lastAnnounceTime":
 					case "nextAnnounceTime":

--- a/src/tr-web-control/script/system.js
+++ b/src/tr-web-control/script/system.js
@@ -2797,6 +2797,8 @@ var system = {
 			for (var key in item) {
 				rowdata[key] = item[key];
 			}
+			// 使用同类已有的翻译文本
+			rowdata.isUTP = system.lang.torrent.attribute["status"][item.isUTP];
 			var percentDone = parseFloat(item.progress * 100).toFixed(2);
 			rowdata.progress = system.getTorrentProgressBar(percentDone, transmission._status.download)
 			datas.push(rowdata);

--- a/src/tr-web-control/template/dialog-torrent-attribute-add-tracker.html
+++ b/src/tr-web-control/template/dialog-torrent-attribute-add-tracker.html
@@ -28,9 +28,11 @@
 			background: "#e6e6e6"
 		});
 
-		title = "button-ok,button-cancel".split(",");
+		title = "button-search-best-ip,button-search-all-ip,button-ok,button-cancel".split(",");
 		$.each(title, function (i, item) {
 			thisDialog.find("#torrent-attribute-add-tracker-" + item).html(system.lang.dialog["public"][item]);
+			thisDialog.find("#torrent-attribute-add-tracker-" + item).html(system.lang.dialog[
+				"torrent-attribute-add-tracker"][item]);
 		});
 
 		thisDialog.find("#text-nochange").html(system.lang["public"]["text-nochange"]);
@@ -83,14 +85,14 @@
         thisDialog.find("#torrent-attribute-add-tracker-button-search-best-ip").click(function () {
             var trackersURL = "https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best_ip.txt"
             $.get(trackersURL,function(data){
-                $("#txtTrackers").html(data);
+                $("#txtTrackers").html(data.replace(/[\r\n]+/g,"\n"));
             });
         });
 
         thisDialog.find("#torrent-attribute-add-tracker-button-search-all-ip").click(function () {
             var trackersURL="https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_all_ip.txt"
             $.get(trackersURL,function(data){
-                $("#txtTrackers").html(data);
+                $("#txtTrackers").html(data.replace(/[\r\n]+/g,"\n"));
             });
         });
         

--- a/src/tr-web-control/template/torrent-attribute-servers-fields.json
+++ b/src/tr-web-control/template/torrent-attribute-servers-fields.json
@@ -10,7 +10,9 @@
 		{"field":"announce","width":"300"}
 		,{"field":"announceState","width":"50"}
 		,{"field":"lastAnnounceResult","width":"180"}
-		,{"field":"downloadCount","width":"70","align":"left"}
+		,{"field":"downloadCount","width":"60","align":"left"}
+		,{"field":"leecherCount","width":"60","align":"left"}
+		,{"field":"seederCount","width":"60","align":"left"}
 		,{"field":"lastAnnounceSucceeded","width":"60","align":"center"}
 		,{"field":"lastAnnounceTime","width":"120","align":"center"}
 		,{"field":"lastAnnounceTimedOut","width":"60","align":"center"}

--- a/src/tr-web-control/template/torrent-attribute-users-fields.json
+++ b/src/tr-web-control/template/torrent-attribute-users-fields.json
@@ -7,6 +7,8 @@
 	}
 	,"fields":[
 		{"field":"address","width":"260"}
+		,{"field":"port","width":"60"}
+		,{"field":"isUTP","width":"60","align":"center"}
 		,{"field":"clientName","width":"120"}
 		,{"field":"flagStr","width":"60"}
 		,{"field":"progress","width":"70","align":"center"}


### PR DESCRIPTION
完成 #339 的需求
1. 已连接用户显示端口和UTP状态
2. 显示tracker服务器的吸血和种子数量，调整状态的文本
3. 去掉添加在线tracker服务器的空行

没弄明白git的用法，PR打扰了抱歉。