### PR TITLE
FreeBSD detection and FreeBSD ps(1) compatibility fix

### DIFF
--- a/release/install-tr-control-cn.sh
+++ b/release/install-tr-control-cn.sh
@@ -403,10 +403,14 @@ getTransmissionPath() {
 	if [ -f "/etc/fedora-release" ] || [ -f "/etc/debian_version" ]; then
 		ROOT_FOLDER="/usr/share/transmission"
 	fi
+	
+	if [ -f "/bin/freebsd-version" ]; then
+		ROOT_FOLDER="/usr/local/share/transmission"
+	fi
 
 	if [ ! -d "$ROOT_FOLDER" ]; then
 		showLog "$MSG_FIND_WEB_FOLDER_FROM_PROCESS" "n"
-		infos=`ps -ef | awk '/[t]ransmission-da/{print $8}'`
+		infos=`ps -Aww -o command= | sed -r -e '/[t]ransmission-da/!d' -e 's/ .+//'`
 		if [ "$infos" != "" ]; then
 			echo " √"
 			search="bin/transmission-daemon"

--- a/release/install-tr-control.sh
+++ b/release/install-tr-control.sh
@@ -406,7 +406,7 @@ getTransmissionPath() {
 
 	if [ ! -d "$ROOT_FOLDER" ]; then
 		showLog "$MSG_FIND_WEB_FOLDER_FROM_PROCESS" "n"
-		infos=`ps -ef | awk '/[t]ransmission-da/{print $8}'`
+		infos=`ps -Aww -o command= | sed -r -e '/[t]ransmission-da/!d' -e 's/ .+//'`
 		if [ "$infos" != "" ]; then
 			echo " √"
 			search="bin/transmission-daemon"


### PR DESCRIPTION
`ps -e` 在FreeBSD中含义与GNU Linux不同，所以更换成了`ps -A` ，以兼容更多操作系统。
另外使用`ps -o command=` 替换`awk`硬编码方式