### PR TITLE
getTransmissionPath for OpenWRT

### DIFF
--- a/release/install-tr-control.sh
+++ b/release/install-tr-control.sh
@@ -400,7 +400,7 @@ getTransmissionPath() {
 	# 用户如知道自己的 Transmission Web 所在的目录，直接修改这个值，以避免搜索所有目录
 	# ROOT_FOLDER="/usr/local/transmission/share/transmission"
 	# Fedora 或 Debian 发行版的默认 ROOT_FOLDER 目录
-	if [ -f "/etc/fedora-release" ] || [ -f "/etc/debian_version" ]; then
+	if [ -f "/etc/fedora-release" ] || [ -f "/etc/debian_version" ] || [ -f "/etc/openwrt_release" ]; then
 		ROOT_FOLDER="/usr/share/transmission"
 	fi
 


### PR DESCRIPTION
I added `|| [ -f "/etc/openwrt_release" ]` on the function `getTransmissionPath()` to

~~~bash
if [ -f "/etc/fedora-release" ] || [ -f "/etc/debian_version" ] || [ -f "/etc/openwrt_version" ]; then
		ROOT_FOLDER="/usr/share/transmission"
fi
~~~

so the root folder is recognized on [OpenWRT](http://www.openwrt.org) for installation or update.
That path is align with the [OpenWRT package](https://github.com/openwrt/packages/tree/master/net/transmission-web-control).

I tested it on OpenWRT v19.

These are the contents of `/etc`:
~~~
-rw-r--r--    1 root     root        1.0K Jul 10 23:06 banner
-rw-r--r--    1 root     root         461 Jul 10 23:06 banner.failsafe
-rw-r--r--    1 root     root        1.6K May 16 15:32 board.json
-rw-r--r--    1 root     root         123 May 16 15:32 device_info
-rw-r--r--    1 root     root         872 May 16 15:32 diag.sh
-rw-------    1 root     root        1.3K May 16 15:32 dnsmasq.conf
-rw-r--r--    1 root     root          97 Jul  7 18:43 environment
-rw-r--r--    1 root     root         130 May 16 15:32 ethers
-rw-------    1 root     root         352 Jul 26 07:23 firewall.user
-rw-r--r--    1 root     root          61 May 16 15:32 fstab
-rw-r--r--    1 root     root          29 Aug  4 10:20 gitconfig
-rw-r--r--    1 root     root         253 Aug 22 09:06 group
-rw-r--r--    1 root     root         110 May 16 15:32 hosts
-rw-------    1 root     root         305 May 16 15:32 hotplug-preinit.json
-rw-------    1 root     root        1.4K May 16 15:32 hotplug.json
-rw-r--r--    1 root     root         175 May 16 15:32 inittab
lrwxrwxrwx    1 root     root          31 Aug  4 09:38 localtime -> /usr/share/zoneinfo/Brazil/East
lrwxrwxrwx    1 root     root          12 May 16 15:32 mtab -> /proc/mounts
-rw-r--r--    1 root     root         767 Jul  7 18:43 netconfig
-rw-r--r--    1 root     root         232 May 16 15:32 openwrt_release
-rw-r--r--    1 root     root          18 May 16 15:32 openwrt_version
-rw-r--r--    1 root     root         114 Jul 14 23:18 opkg.conf
lrwxrwxrwx    1 root     root          21 May 16 15:32 os-release -> ../usr/lib/os-release
-rw-r--r--    1 root     root         552 Jul  7 18:43 pam.conf
-rw-r--r--    1 root     root         454 Aug 22 09:12 passwd
-rw-r--r--    1 root     root         244 May 16 15:32 passwd-
-rw-r--r--    1 root     root        4.4K Aug  4 08:38 php.ini
-rw-r--r--    1 root     root        4.4K Sep  6 13:19 php.ini-opkg
-rwxr-xr-x    1 root     root         609 May 16 15:32 preinit
-rw-r--r--    1 root     root        1.5K Aug 22 09:11 profile
-rw-r--r--    1 root     root        2.5K May 16 15:32 protocols
-rwxr-xr-x    1 root     root        2.4K May 16 15:32 rc.common
-rw-r--r--    1 root     root         132 May 16 15:32 rc.local
lrwxrwxrwx    1 root     root          16 May 16 15:32 resolv.conf -> /tmp/resolv.conf
-rw-r--r--    1 root     root         315 Aug 22 08:39 rsyncd.conf
-rw-r--r--    1 root     root        3.0K May 16 15:32 services
-rw-------    1 root     root         231 Jul 10 18:10 shadow
-rw-------    1 root     root         140 May 16 15:32 shadow-
-rw-r--r--    1 root     root          30 Jul 11 17:56 shells
-rw-r--r--    1 root     root          80 May 16 15:32 sysctl.conf
-rw-r--r--    1 root     root         128 May 16 15:32 sysupgrade.conf
-rw-------    1 root     root         512 May 16 15:35 urandom.seed
-rw-r--r--    1 root     root         642 Jul  7 18:43 xattr.conf
~~~