### PR TITLE
修复 某些情况下默认保存目录不出现在下载目录列表中

### DIFF
--- a/src/tr-web-control/script/transmission.torrents.js
+++ b/src/tr-web-control/script/transmission.torrents.js
@@ -91,7 +91,9 @@ transmission.torrents = {
 		this.warning = new Array();
 		this.btItems = new Array();
 		// All download directories used by current torrents
-		transmission.downloadDirs = new Array();
+		if (transmission.downloadDirs == undefined){
+			transmission.downloadDirs = new Array();
+		}
 
 		var _Status = transmission._status;
 		this.status = {};


### PR DESCRIPTION
修复: transmission.downloadDirs会在transmission.torrents.js中被重新初始化从而丢失默认保存目录