### PR TITLE
Update install-tr-control.sh (prevent searching for web dir on external drives)

### DIFF
--- a/release/install-tr-control.sh
+++ b/release/install-tr-control.sh
@@ -160,7 +160,7 @@ findWebFolder() {
 			showLog "$ROOT_FOLDER/web $MSG_AVAILABLE."
 		else
 			showLog "$MSG_THE_SPECIFIED_DIRECTORY_DOES_NOT_EXIST"
-			ROOT_FOLDER=`find / -name 'web' -type d 2>/dev/null| grep 'transmission/web' | sed 's/\/web$//g'`
+			ROOT_FOLDER=`find /usr /etc /home /root -name 'web' -type d 2>/dev/null| grep 'transmission/web' | sed 's/\/web$//g'`
 
 			if [ -d "$ROOT_FOLDER/web" ]; then
 				WEB_FOLDER="$ROOT_FOLDER/web"


### PR DESCRIPTION
Please either use find to search only in common directories like i propose (PS: i do not know whether to include more like /var maybe) or use "-mount" parameter to a find command which would prevent scanning mounted external drives. In my case current version takes more than 30 minutes to complete scan due to external drive mount points.. It was hammering my ext. drives while i think it is very rare case people put the web dir. manually on ext. drive mount point?