### PR TITLE
Update install-tr-control.sh

### DIFF
--- a/release/install-tr-control.sh
+++ b/release/install-tr-control.sh
@@ -248,7 +248,8 @@ download() {
 	fi
 	showLog "$MSG_DOWNLOADING"
 	echo ""
-	wget "$DOWNLOAD_URL" --no-check-certificate
+	# 下载的时候强制命名文件，以免被重定向后文件名发生改变
+	wget "$DOWNLOAD_URL" -O "$PACK_NAME" --no-check-certificate
 	# 判断是否下载成功
 	if [ $? -eq 0 ]; then
 		showLog "$MSG_DOWNLOAD_COMPLETE"
@@ -436,7 +437,9 @@ getTransmissionPath() {
 # 获取最后的发布版本号
 # 因在源码库里提交二进制文件不便于管理，以后将使用这种方式获取最新发布的版本
 getLatestReleases() {
-	VERSION=`wget -O - https://api.github.com/repos/ronggang/transmission-web-control/releases/latest | grep tag_name | head -n 1 | cut -d '"' -f 4`
+	# VERSION=`wget -O - https://api.github.com/repos/ronggang/transmission-web-control/releases/latest | grep tag_name | head -n 1 | cut -d '"' -f 4`
+	# 换为curl，避免OpenWRT下wget得到的内容没有分行，导致grep输出结果失效
+	VERSION=`curl -s https://api.github.com/repos/ronggang/transmission-web-control/releases/latest | grep tag_name | head -n 1 | cut -d '"' -f 4`
 }
 
 # 检测 Transmission 进程是否存在


### PR DESCRIPTION
改动了2个地方，
#252，wget下载安装包时强制命名文件，因为发现下载路径被重定向以后文件名发生变化，没有.tar.gz，导致后续解压处理失败
#442，在OpenWRT下wget得到的内容没有分行符，导致grep结果为页面全部内容，造成head命令失效，建议改为curl -s，这样可以准确输出一行