### PR TITLE
对于下载目录结尾有斜杠"/"或没有的进行统一以便去重。

### DIFF
--- a/src/tr-web-control/template/dialog-torrent-add.html
+++ b/src/tr-web-control/template/dialog-torrent-add.html
@@ -79,6 +79,9 @@
 		{
 			$.merge(downloadDirs,system.dictionary.folders.split("\n"));
 		}
+		downloadDirs = downloadDirs.map(item => {
+			return item[item.length - 1] == '/' ? item.slice(0, -1) : item;
+		});
 		downloadDirs = uniq(downloadDirs);
 
 		if (system.config.hideSubfolders == false && system.currentListDir != null && system.currentListDir != "") {

--- a/src/tr-web-control/template/dialog-torrent-addfile.html
+++ b/src/tr-web-control/template/dialog-torrent-addfile.html
@@ -68,6 +68,9 @@
 		{
 			$.merge(downloadDirs,system.dictionary.folders.split("\n"));
 		}
+		downloadDirs = downloadDirs.map(item => {
+			return item[item.length - 1] == '/' ? item.slice(0, -1) : item;
+		});
 		downloadDirs = uniq(downloadDirs);
 		
 		if (system.config.hideSubfolders == false && system.currentListDir != null && system.currentListDir != "") {


### PR DESCRIPTION
类似这个 https://github.com/ronggang/transmission-web-control/issues/576，我也碰到同样的问题了，会显示很多个仅仅是结尾斜杠不同的目录。

关于结尾是应该有斜杠还是没有，这个一直都有争议，我暂时按没有实现的。