### PR TITLE
fix - 修复如果本地用户标签太多会显示不全的问题

### DIFF
--- a/src/tr-web-control/template/dialog-torrent-add.html
+++ b/src/tr-web-control/template/dialog-torrent-add.html
@@ -40,16 +40,17 @@
 		</div>
 
 		<!-- label -->
-		<div data-options="region:'center'" style="padding:3px;border:0px;overflow: hidden;">
-			<div id="label_page" class="dialog" style="width:100%;padding:0px;height:50%;border-bottom: 1px dotted #ccc;">
-				<div style="position: absolute;width:50%;height: 100%;">
-					<div system-lang="dialog['torrent-setLabels']['available']"></div>
-					<div id="divAvailableList" style="padding-top: 5px;"></div>
-				</div>
-				<div style="position: absolute;left:50%;width:50%;height: 50%;border-left: 1px dotted #ccc;padding-left: 5px;">
+		<div data-options="region:'center'" style="padding:3px;border:0px;height:41%;">
+			<div id="label_page" class="dialog" style="width:100%;height:100%;padding:0px;border-bottom: 1px dotted #ccc;">
+				<div style="overflow-y:auto;width:49%;height:100%;border-left: 1px dotted #ccc;padding-left: 5px;float:right;">
 					<div system-lang="dialog['torrent-setLabels']['selected']"></div>
 					<div id="divSelectedList" style="padding-top: 5px;"></div>
 				</div>
+				<div style="overflow-y:auto;width:49%;height:100%;">
+					<div system-lang="dialog['torrent-setLabels']['available']"></div>
+					<div id="divAvailableList" style="padding-top: 5px;"></div>
+				</div>
+                <div style="clear:right;"></div>
 			</div>
 		</div>
 	</div>

--- a/src/tr-web-control/template/dialog-torrent-addfile.html
+++ b/src/tr-web-control/template/dialog-torrent-addfile.html
@@ -30,16 +30,17 @@
 		</div>
 
 		<!-- label -->
-		<div data-options="region:'center'" style="padding:3px;border:0px;overflow: hidden;">
-			<div id="label_page" class="dialog" style="width:100%;padding:0px;height:50%;border-bottom: 1px dotted #ccc;">
-				<div style="position: absolute;width:50%;height: 100%;">
-					<div system-lang="dialog['torrent-setLabels']['available']"></div>
-					<div id="divAvailableList" style="padding-top: 5px;"></div>
-				</div>
-				<div style="position: absolute;left:50%;width:50%;height: 50%;border-left: 1px dotted #ccc;padding-left: 5px;">
+		<div data-options="region:'center'" style="padding:3px;border:0px;height:47%;">
+			<div id="label_page" class="dialog" style="width:100%;height:100%;padding:0px;border-bottom: 1px dotted #ccc;">
+				<div style="overflow-y:auto;width:49%;height:100%;border-left: 1px dotted #ccc;padding-left: 5px;float:right;">
 					<div system-lang="dialog['torrent-setLabels']['selected']"></div>
 					<div id="divSelectedList" style="padding-top: 5px;"></div>
 				</div>
+				<div style="overflow-y:auto;width:49%;height:100%;">
+					<div system-lang="dialog['torrent-setLabels']['available']"></div>
+					<div id="divAvailableList" style="padding-top: 5px;"></div>
+				</div>
+                <div style="clear:right;"></div>
 			</div>
 		</div>
 	</div>  

--- a/src/tr-web-control/template/dialog-torrent-setLabels.html
+++ b/src/tr-web-control/template/dialog-torrent-setLabels.html
@@ -1,11 +1,11 @@
 <div class="easyui-layout" data-options="fit:true" style="width:100%;height:100%;">
 	<div data-options="region:'center'" style="padding:3px;border:0px;overflow: hidden;">
 		<div id="" class="dialog" style="width:100%;padding:0px;height:100%;border-bottom: 1px dotted #ccc;">
-			<div style="position: absolute;width:50%;height: 100%;">
+			<div style="position: absolute;overflow-y:auto;width:49%;height:100%">
 				<div system-lang="dialog['torrent-setLabels']['available']"></div>
 				<div id="divAvailableList" style="padding-top: 5px;"></div>
 			</div>
-			<div style="position: absolute;left:50%;width:50%;height: 100%;border-left: 1px dotted #ccc;padding-left: 5px;">
+			<div style="position: absolute;left:50%;overflow-y:auto;width:49%;height:100%;border-left: 1px dotted #ccc;padding-left: 5px;">
 				<div system-lang="dialog['torrent-setLabels']['selected']"></div>
 				<div id="divSelectedList" style="padding-top: 5px;"></div>
 			</div>


### PR DESCRIPTION
当用户标签内容太长或者数量太多，数量达到在原有设置标签列表展示界面中显示不全时，自动添加滚动条支持以显示用户全部的标签！